### PR TITLE
chore(deps): bump @types/bcryptjs to ^3.0.0 in templates

### DIFF
--- a/generators/auth_jwt_clean_arch_module/generator.go
+++ b/generators/auth_jwt_clean_arch_module/generator.go
@@ -65,7 +65,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 				"bcryptjs": "^2.4.3",
 			},
 			"devDependencies": map[string]interface{}{
-				"@types/bcryptjs": "^2.4.6",
+				"@types/bcryptjs": "^3.0.0",
 			},
 		})
 		return nil

--- a/generators/auth_jwt_clean_arch_module/manifest.go
+++ b/generators/auth_jwt_clean_arch_module/manifest.go
@@ -4,7 +4,7 @@ import "github.com/version14/dot/pkg/dotapi"
 
 var Manifest = dotapi.Manifest{
 	Name:        "auth_jwt_clean_arch_module",
-	Version:     "0.1.0",
+	Version:     "0.2.0",
 	Description: "JWT auth module for Clean Architecture (use-cases, controller, repository, domain)",
 	DependsOn:   []string{"auth_jwt_vanilla", "auth_jwt_users_schema"},
 	Outputs: []string{


### PR DESCRIPTION
## Dependency bump

Bumps `@types/bcryptjs` (npm) to `^3.0.0` in template generators.

### Affected generators

- `auth_jwt_clean_arch_module `

---
🤖 Generated by [dep-checker](../tree/main/tools/dep-checker)