### PR TITLE
chore(deps): bump @types/cookie-parser to ^1.4.10 in templates

### DIFF
--- a/generators/auth_better_auth/generator.go
+++ b/generators/auth_better_auth/generator.go
@@ -33,7 +33,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 				"cookie-parser": "^1.4.7",
 			},
 			"devDependencies": map[string]interface{}{
-				"@types/cookie-parser": "^1.4.8",
+				"@types/cookie-parser": "^1.4.10",
 			},
 		})
 		return nil

--- a/generators/auth_better_auth/manifest.go
+++ b/generators/auth_better_auth/manifest.go
@@ -4,7 +4,7 @@ import "github.com/version14/dot/pkg/dotapi"
 
 var Manifest = dotapi.Manifest{
 	Name:        "auth_better_auth",
-	Version:     "0.2.0",
+	Version:     "0.2.1",
 	Description: "BetterAuth setup with Drizzle adapter: src/lib/auth.ts plus a direct toNodeHandler mount in src/app.ts (no intermediate route file)",
 	DependsOn:   []string{"drizzle_postgres_adapter"},
 	Outputs: []string{

--- a/generators/auth_jwt_vanilla/generator.go
+++ b/generators/auth_jwt_vanilla/generator.go
@@ -35,7 +35,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 			},
 			"devDependencies": map[string]interface{}{
 				"@types/jsonwebtoken":  "^9.0.7",
-				"@types/cookie-parser": "^1.4.8",
+				"@types/cookie-parser": "^1.4.10",
 			},
 		})
 		return nil

--- a/generators/auth_jwt_vanilla/manifest.go
+++ b/generators/auth_jwt_vanilla/manifest.go
@@ -4,7 +4,7 @@ import "github.com/version14/dot/pkg/dotapi"
 
 var Manifest = dotapi.Manifest{
 	Name:        "auth_jwt_vanilla",
-	Version:     "0.1.0",
+	Version:     "0.1.1",
 	Description: "Vanilla JWT authentication: src/shared/services/jwt.ts utility and src/shared/middlewares/auth.middleware.ts",
 	DependsOn:   []string{"express_server_entrypoint"},
 	Outputs: []string{


### PR DESCRIPTION
## Dependency bump

Bumps `@types/cookie-parser` (npm) to `^1.4.10` in template generators.

### Affected generators

- `auth_better_auth `
- `auth_jwt_vanilla `

---
🤖 Generated by [dep-checker](../tree/main/tools/dep-checker)