### PR TITLE
chore(deps): bump @types/cors to ^2.8.19 in templates

### DIFF
--- a/generators/express_server_typescript_deps/generator.go
+++ b/generators/express_server_typescript_deps/generator.go
@@ -26,7 +26,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 				"express": "^4.21.0",
 			},
 			"devDependencies": map[string]interface{}{
-				"@types/cors":    "^2.8.17",
+				"@types/cors":    "^2.8.19",
 				"@types/express": "^5.0.0",
 				"@types/node":    "^22.0.0",
 				"nodemon":        "^3.1.0",

--- a/generators/express_server_typescript_deps/manifest.go
+++ b/generators/express_server_typescript_deps/manifest.go
@@ -4,7 +4,7 @@ import "github.com/version14/dot/pkg/dotapi"
 
 var Manifest = dotapi.Manifest{
 	Name:        "express_server_typescript_deps",
-	Version:     "0.1.0",
+	Version:     "0.1.1",
 	Description: "Express + CORS + dotenv npm dependencies and dev/build/start scripts for TypeScript projects",
 	DependsOn:   []string{"express_server_entrypoint"},
 	Outputs:     []string{},


### PR DESCRIPTION
## Dependency bump

Bumps `@types/cors` (npm) to `^2.8.19` in template generators.

### Affected generators

- `express_server_typescript_deps `

---
🤖 Generated by [dep-checker](../tree/main/tools/dep-checker)