### PR TITLE
chore(deps): bump @types/jsonwebtoken to ^9.0.10 in templates

### DIFF
--- a/generators/auth_jwt_vanilla/generator.go
+++ b/generators/auth_jwt_vanilla/generator.go
@@ -34,7 +34,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 				"cookie-parser": "^1.4.7",
 			},
 			"devDependencies": map[string]interface{}{
-				"@types/jsonwebtoken":  "^9.0.7",
+				"@types/jsonwebtoken":  "^9.0.10",
 				"@types/cookie-parser": "^1.4.8",
 			},
 		})

--- a/generators/auth_jwt_vanilla/manifest.go
+++ b/generators/auth_jwt_vanilla/manifest.go
@@ -4,7 +4,7 @@ import "github.com/version14/dot/pkg/dotapi"
 
 var Manifest = dotapi.Manifest{
 	Name:        "auth_jwt_vanilla",
-	Version:     "0.1.0",
+	Version:     "0.1.1",
 	Description: "Vanilla JWT authentication: src/shared/services/jwt.ts utility and src/shared/middlewares/auth.middleware.ts",
 	DependsOn:   []string{"express_server_entrypoint"},
 	Outputs: []string{


### PR DESCRIPTION
## Dependency bump

Bumps `@types/jsonwebtoken` (npm) to `^9.0.10` in template generators.

### Affected generators

- `auth_jwt_vanilla `

---
🤖 Generated by [dep-checker](../tree/main/tools/dep-checker)