### PR TITLE
chore(deps): bump @types/react to ^19.2.15 in templates

### DIFF
--- a/generators/react_app/generator.go
+++ b/generators/react_app/generator.go
@@ -35,7 +35,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 				"react-dom": "^18.3.0",
 			},
 			"devDependencies": map[string]interface{}{
-				"@types/react":         "^18.3.0",
+				"@types/react":         "^19.2.15",
 				"@types/react-dom":     "^18.3.0",
 				"@vitejs/plugin-react": "^4.3.0",
 				"vite":                 "^5.4.0",

--- a/generators/react_app/manifest.go
+++ b/generators/react_app/manifest.go
@@ -10,7 +10,7 @@ import (
 // project needs the TypeScript foundation first.
 var Manifest = dotapi.Manifest{
 	Name:        "react_app",
-	Version:     "0.1.0",
+	Version:     "0.2.0",
 	Description: "React + Vite application setup",
 	DependsOn:   []string{"typescript_base"},
 	Outputs: []string{


### PR DESCRIPTION
## Dependency bump

Bumps `@types/react` (npm) to `^19.2.15` in template generators.

### Affected generators

- `react_app `

---
🤖 Generated by [dep-checker](../tree/main/tools/dep-checker)