### PR TITLE
chore(deps): bump @types/swagger-ui-express to ^4.1.8 in templates

### DIFF
--- a/generators/express_swagger_jsdoc/generator.go
+++ b/generators/express_swagger_jsdoc/generator.go
@@ -36,7 +36,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 			},
 			"devDependencies": map[string]interface{}{
 				"@types/swagger-jsdoc":      "^6.0.4",
-				"@types/swagger-ui-express": "^4.1.6",
+				"@types/swagger-ui-express": "^4.1.8",
 			},
 		})
 		return nil

--- a/generators/express_swagger_jsdoc/manifest.go
+++ b/generators/express_swagger_jsdoc/manifest.go
@@ -4,7 +4,7 @@ import "github.com/version14/dot/pkg/dotapi"
 
 var Manifest = dotapi.Manifest{
 	Name:        "express_swagger_jsdoc",
-	Version:     "0.1.0",
+	Version:     "0.1.1",
 	Description: "Classic JSDoc-driven Swagger/OpenAPI: scans source files for @openapi comments, builds the spec at boot, and mounts swagger-ui at /docs",
 	DependsOn:   []string{"express_server_entrypoint"},
 	Outputs: []string{

--- a/generators/zod_validation_deps/generator.go
+++ b/generators/zod_validation_deps/generator.go
@@ -22,7 +22,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 				"swagger-ui-express":             "^5.0.1",
 			},
 			"devDependencies": map[string]interface{}{
-				"@types/swagger-ui-express": "^4.1.6",
+				"@types/swagger-ui-express": "^4.1.8",
 			},
 		})
 		return nil

--- a/generators/zod_validation_deps/manifest.go
+++ b/generators/zod_validation_deps/manifest.go
@@ -6,7 +6,7 @@ var packageFileName = "package.json"
 
 var Manifest = dotapi.Manifest{
 	Name:        "zod_validation_deps",
-	Version:     "0.1.0",
+	Version:     "0.1.1",
 	Description: "Adds Zod, zod-to-openapi, swagger-ui-express, and reflect-metadata dependencies plus tsconfig flags for decorator metadata",
 	DependsOn:   []string{"typescript_base"},
 	Outputs:     []string{},


### PR DESCRIPTION
## Dependency bump

Bumps `@types/swagger-ui-express` (npm) to `^4.1.8` in template generators.

### Affected generators

- `express_swagger_jsdoc `
- `zod_validation_deps `

---
🤖 Generated by [dep-checker](../tree/main/tools/dep-checker)