### PR TITLE
chore(deps): bump @vitejs/plugin-react to ^6.0.2 in templates

### DIFF
--- a/generators/react_app/generator.go
+++ b/generators/react_app/generator.go
@@ -37,7 +37,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 			"devDependencies": map[string]interface{}{
 				"@types/react":         "^18.3.0",
 				"@types/react-dom":     "^18.3.0",
-				"@vitejs/plugin-react": "^4.3.0",
+				"@vitejs/plugin-react": "^6.0.2",
 				"vite":                 "^5.4.0",
 			},
 		})

--- a/generators/react_app/manifest.go
+++ b/generators/react_app/manifest.go
@@ -10,7 +10,7 @@ import (
 // project needs the TypeScript foundation first.
 var Manifest = dotapi.Manifest{
 	Name:        "react_app",
-	Version:     "0.1.0",
+	Version:     "0.2.0",
 	Description: "React + Vite application setup",
 	DependsOn:   []string{"typescript_base"},
 	Outputs: []string{


### PR DESCRIPTION
## Dependency bump

Bumps `@vitejs/plugin-react` (npm) to `^6.0.2` in template generators.

### Affected generators

- `react_app `

---
🤖 Generated by [dep-checker](../tree/main/tools/dep-checker)