### PR TITLE
chore(deps): bump better-auth to ^1.6.11 in templates

### DIFF
--- a/generators/auth_better_auth/generator.go
+++ b/generators/auth_better_auth/generator.go
@@ -29,7 +29,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 	if err := ctx.State.UpdateJSON("package.json", func(d *state.JSONDoc) error {
 		d.Merge(map[string]interface{}{
 			"dependencies": map[string]interface{}{
-				"better-auth":   "^1.2.0",
+				"better-auth":   "^1.6.11",
 				"cookie-parser": "^1.4.7",
 			},
 			"devDependencies": map[string]interface{}{

--- a/generators/auth_better_auth/manifest.go
+++ b/generators/auth_better_auth/manifest.go
@@ -4,7 +4,7 @@ import "github.com/version14/dot/pkg/dotapi"
 
 var Manifest = dotapi.Manifest{
 	Name:        "auth_better_auth",
-	Version:     "0.2.0",
+	Version:     "0.2.1",
 	Description: "BetterAuth setup with Drizzle adapter: src/lib/auth.ts plus a direct toNodeHandler mount in src/app.ts (no intermediate route file)",
 	DependsOn:   []string{"drizzle_postgres_adapter"},
 	Outputs: []string{


### PR DESCRIPTION
## Dependency bump

Bumps `better-auth` (npm) to `^1.6.11` in template generators.

### Affected generators

- `auth_better_auth `

---
🤖 Generated by [dep-checker](../tree/main/tools/dep-checker)