### PR TITLE
chore(deps): bump cors to ^2.8.6 in templates

### DIFF
--- a/generators/express_server_typescript_deps/generator.go
+++ b/generators/express_server_typescript_deps/generator.go
@@ -21,7 +21,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 				"start": "node dist/index.js",
 			},
 			"dependencies": map[string]interface{}{
-				"cors":    "^2.8.5",
+				"cors":    "^2.8.6",
 				"dotenv":  "^16.4.0",
 				"express": "^4.21.0",
 			},

--- a/generators/express_server_typescript_deps/manifest.go
+++ b/generators/express_server_typescript_deps/manifest.go
@@ -4,7 +4,7 @@ import "github.com/version14/dot/pkg/dotapi"
 
 var Manifest = dotapi.Manifest{
 	Name:        "express_server_typescript_deps",
-	Version:     "0.1.0",
+	Version:     "0.1.1",
 	Description: "Express + CORS + dotenv npm dependencies and dev/build/start scripts for TypeScript projects",
 	DependsOn:   []string{"express_server_entrypoint"},
 	Outputs:     []string{},


### PR DESCRIPTION
## Dependency bump

Bumps `cors` (npm) to `^2.8.6` in template generators.

### Affected generators

- `express_server_typescript_deps `

---
🤖 Generated by [dep-checker](../tree/main/tools/dep-checker)