### PR TITLE
chore(deps): bump dotenv to ^17.4.2 in templates

### DIFF
--- a/generators/express_server_typescript_deps/generator.go
+++ b/generators/express_server_typescript_deps/generator.go
@@ -22,7 +22,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 			},
 			"dependencies": map[string]interface{}{
 				"cors":    "^2.8.5",
-				"dotenv":  "^16.4.0",
+				"dotenv":  "^17.4.2",
 				"express": "^4.21.0",
 			},
 			"devDependencies": map[string]interface{}{

--- a/generators/express_server_typescript_deps/manifest.go
+++ b/generators/express_server_typescript_deps/manifest.go
@@ -4,7 +4,7 @@ import "github.com/version14/dot/pkg/dotapi"
 
 var Manifest = dotapi.Manifest{
 	Name:        "express_server_typescript_deps",
-	Version:     "0.1.0",
+	Version:     "0.2.0",
 	Description: "Express + CORS + dotenv npm dependencies and dev/build/start scripts for TypeScript projects",
 	DependsOn:   []string{"express_server_entrypoint"},
 	Outputs:     []string{},


### PR DESCRIPTION
## Dependency bump

Bumps `dotenv` (npm) to `^17.4.2` in template generators.

### Affected generators

- `express_server_typescript_deps `

---
🤖 Generated by [dep-checker](../tree/main/tools/dep-checker)