### PR TITLE
chore(deps): bump drizzle-orm to ^0.45.2 in templates

### DIFF
--- a/generators/drizzle_typescript_deps/generator.go
+++ b/generators/drizzle_typescript_deps/generator.go
@@ -22,7 +22,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 				"db:studio":   "drizzle-kit studio",
 			},
 			"dependencies": map[string]interface{}{
-				"drizzle-orm": "^0.44.0",
+				"drizzle-orm": "^0.45.2",
 			},
 			"devDependencies": map[string]interface{}{
 				"drizzle-kit": "^0.30.0",

--- a/generators/drizzle_typescript_deps/manifest.go
+++ b/generators/drizzle_typescript_deps/manifest.go
@@ -6,7 +6,7 @@ const PACKAGE_JSON = "package.json"
 
 var Manifest = dotapi.Manifest{
 	Name:        "drizzle_typescript_deps",
-	Version:     "0.1.0",
+	Version:     "0.1.1",
 	Description: "Adds drizzle-orm and drizzle-kit to package.json and db:* scripts",
 	DependsOn:   []string{"drizzle_config_base"},
 	Outputs:     []string{},


### PR DESCRIPTION
## Dependency bump

Bumps `drizzle-orm` (npm) to `^0.45.2` in template generators.

### Affected generators

- `drizzle_typescript_deps `

---
🤖 Generated by [dep-checker](../tree/main/tools/dep-checker)