### PR TITLE
chore(deps): bump express-rate-limit to ^8.5.2 in templates

### DIFF
--- a/generators/express_rate_limit/generator.go
+++ b/generators/express_rate_limit/generator.go
@@ -31,7 +31,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 	if err := ctx.State.UpdateJSON("package.json", func(d *state.JSONDoc) error {
 		d.Merge(map[string]interface{}{
 			"dependencies": map[string]interface{}{
-				"express-rate-limit": "^7.4.1",
+				"express-rate-limit": "^8.5.2",
 			},
 		})
 		return nil

--- a/generators/express_rate_limit/manifest.go
+++ b/generators/express_rate_limit/manifest.go
@@ -4,7 +4,7 @@ import "github.com/version14/dot/pkg/dotapi"
 
 var Manifest = dotapi.Manifest{
 	Name:        "express_rate_limit",
-	Version:     "0.1.0",
+	Version:     "0.2.0",
 	Description: "Adds express-rate-limit with a default 100 req/15min window applied globally",
 	DependsOn:   []string{"express_server_entrypoint"},
 	Outputs:     []string{"src/shared/middlewares/rate-limit.middleware.ts"},


### PR DESCRIPTION
## Dependency bump

Bumps `express-rate-limit` (npm) to `^8.5.2` in template generators.

### Affected generators

- `express_rate_limit `

---
🤖 Generated by [dep-checker](../tree/main/tools/dep-checker)