### PR TITLE
chore(deps): bump express to ^5.2.1 in templates

### DIFF
--- a/generators/express_server_typescript_deps/generator.go
+++ b/generators/express_server_typescript_deps/generator.go
@@ -23,7 +23,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 			"dependencies": map[string]interface{}{
 				"cors":    "^2.8.5",
 				"dotenv":  "^16.4.0",
-				"express": "^4.21.0",
+				"express": "^5.2.1",
 			},
 			"devDependencies": map[string]interface{}{
 				"@types/cors":    "^2.8.17",

--- a/generators/express_server_typescript_deps/manifest.go
+++ b/generators/express_server_typescript_deps/manifest.go
@@ -4,7 +4,7 @@ import "github.com/version14/dot/pkg/dotapi"
 
 var Manifest = dotapi.Manifest{
 	Name:        "express_server_typescript_deps",
-	Version:     "0.1.0",
+	Version:     "0.2.0",
 	Description: "Express + CORS + dotenv npm dependencies and dev/build/start scripts for TypeScript projects",
 	DependsOn:   []string{"express_server_entrypoint"},
 	Outputs:     []string{},


### PR DESCRIPTION
## Dependency bump

Bumps `express` (npm) to `^5.2.1` in template generators.

### Affected generators

- `express_server_typescript_deps `

---
🤖 Generated by [dep-checker](../tree/main/tools/dep-checker)