### PR TITLE
chore(deps): bump jsonwebtoken to ^9.0.3 in templates

### DIFF
--- a/generators/auth_jwt_vanilla/generator.go
+++ b/generators/auth_jwt_vanilla/generator.go
@@ -30,7 +30,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 	if err := ctx.State.UpdateJSON("package.json", func(d *state.JSONDoc) error {
 		d.Merge(map[string]interface{}{
 			"dependencies": map[string]interface{}{
-				"jsonwebtoken":  "^9.0.2",
+				"jsonwebtoken":  "^9.0.3",
 				"cookie-parser": "^1.4.7",
 			},
 			"devDependencies": map[string]interface{}{

--- a/generators/auth_jwt_vanilla/manifest.go
+++ b/generators/auth_jwt_vanilla/manifest.go
@@ -4,7 +4,7 @@ import "github.com/version14/dot/pkg/dotapi"
 
 var Manifest = dotapi.Manifest{
 	Name:        "auth_jwt_vanilla",
-	Version:     "0.1.0",
+	Version:     "0.1.1",
 	Description: "Vanilla JWT authentication: src/shared/services/jwt.ts utility and src/shared/middlewares/auth.middleware.ts",
 	DependsOn:   []string{"express_server_entrypoint"},
 	Outputs: []string{


### PR DESCRIPTION
## Dependency bump

Bumps `jsonwebtoken` (npm) to `^9.0.3` in template generators.

### Affected generators

- `auth_jwt_vanilla `

---
🤖 Generated by [dep-checker](../tree/main/tools/dep-checker)