### PR TITLE
chore(deps): bump postgres to ^3.4.9 in templates

### DIFF
--- a/generators/drizzle_postgres_adapter/generator.go
+++ b/generators/drizzle_postgres_adapter/generator.go
@@ -27,7 +27,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 	return ctx.State.UpdateJSON("package.json", func(d *state.JSONDoc) error {
 		d.Merge(map[string]interface{}{
 			"dependencies": map[string]interface{}{
-				"postgres": "^3.4.0",
+				"postgres": "^3.4.9",
 			},
 		})
 		return nil

--- a/generators/drizzle_postgres_adapter/manifest.go
+++ b/generators/drizzle_postgres_adapter/manifest.go
@@ -4,7 +4,7 @@ import "github.com/version14/dot/pkg/dotapi"
 
 var Manifest = dotapi.Manifest{
 	Name:        "drizzle_postgres_adapter",
-	Version:     "0.1.0",
+	Version:     "0.1.1",
 	Description: "PostgreSQL driver and database connection file for Drizzle ORM (src/db/index.ts)",
 	DependsOn:   []string{"drizzle_typescript_deps"},
 	Outputs: []string{


### PR DESCRIPTION
## Dependency bump

Bumps `postgres` (npm) to `^3.4.9` in template generators.

### Affected generators

- `drizzle_postgres_adapter `

---
🤖 Generated by [dep-checker](../tree/main/tools/dep-checker)