### PR TITLE
chore(deps): bump prettier to ^3.8.3 in templates

### DIFF
--- a/generators/prettier_typescript_deps/generator.go
+++ b/generators/prettier_typescript_deps/generator.go
@@ -20,7 +20,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 				"format:check": "prettier --check .",
 			},
 			"devDependencies": map[string]interface{}{
-				"prettier": "^3.2.0",
+				"prettier": "^3.8.3",
 			},
 		})
 		return nil

--- a/generators/prettier_typescript_deps/manifest.go
+++ b/generators/prettier_typescript_deps/manifest.go
@@ -4,7 +4,7 @@ import "github.com/version14/dot/pkg/dotapi"
 
 var Manifest = dotapi.Manifest{
 	Name:        "prettier_typescript_deps",
-	Version:     "0.1.0",
+	Version:     "0.1.1",
 	Description: "Adds prettier devDependency and format script to package.json (TypeScript projects)",
 	DependsOn:   []string{"prettier_config", "*"},
 	Outputs:     []string{},


### PR DESCRIPTION
## Dependency bump

Bumps `prettier` (npm) to `^3.8.3` in template generators.

### Affected generators

- `prettier_typescript_deps `

---
🤖 Generated by [dep-checker](../tree/main/tools/dep-checker)