### PR TITLE
chore(deps): bump supertest to ^7.2.2 in templates

### DIFF
--- a/generators/express_test_setup/generator.go
+++ b/generators/express_test_setup/generator.go
@@ -32,7 +32,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 			"devDependencies": map[string]interface{}{
 				"vitest":              "^2.0.0",
 				"@vitest/coverage-v8": "^2.0.0",
-				"supertest":           "^7.0.0",
+				"supertest":           "^7.2.2",
 				"@types/supertest":    "^6.0.0",
 			},
 		})

--- a/generators/express_test_setup/manifest.go
+++ b/generators/express_test_setup/manifest.go
@@ -4,7 +4,7 @@ import "github.com/version14/dot/pkg/dotapi"
 
 var Manifest = dotapi.Manifest{
 	Name:        "express_test_setup",
-	Version:     "0.1.0",
+	Version:     "0.1.1",
 	Description: "Vitest configuration and testing dependencies (vitest, supertest) for Express TypeScript projects",
 	DependsOn:   []string{"express_server_entrypoint"},
 	Outputs:     []string{"vitest.config.ts"},


### PR DESCRIPTION
## Dependency bump

Bumps `supertest` (npm) to `^7.2.2` in template generators.

### Affected generators

- `express_test_setup `

---
🤖 Generated by [dep-checker](../tree/main/tools/dep-checker)