### PR TITLE
chore(deps): bump swagger-jsdoc to ^6.3.0 in templates

### DIFF
--- a/generators/express_swagger_jsdoc/generator.go
+++ b/generators/express_swagger_jsdoc/generator.go
@@ -31,7 +31,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 	if err := ctx.State.UpdateJSON("package.json", func(d *state.JSONDoc) error {
 		d.Merge(map[string]interface{}{
 			"dependencies": map[string]interface{}{
-				"swagger-jsdoc":      "^6.2.8",
+				"swagger-jsdoc":      "^6.3.0",
 				"swagger-ui-express": "^5.0.1",
 			},
 			"devDependencies": map[string]interface{}{

--- a/generators/express_swagger_jsdoc/manifest.go
+++ b/generators/express_swagger_jsdoc/manifest.go
@@ -4,7 +4,7 @@ import "github.com/version14/dot/pkg/dotapi"
 
 var Manifest = dotapi.Manifest{
 	Name:        "express_swagger_jsdoc",
-	Version:     "0.1.0",
+	Version:     "0.1.1",
 	Description: "Classic JSDoc-driven Swagger/OpenAPI: scans source files for @openapi comments, builds the spec at boot, and mounts swagger-ui at /docs",
 	DependsOn:   []string{"express_server_entrypoint"},
 	Outputs: []string{


### PR DESCRIPTION
## Dependency bump

Bumps `swagger-jsdoc` (npm) to `^6.3.0` in template generators.

### Affected generators

- `express_swagger_jsdoc `

---
🤖 Generated by [dep-checker](../tree/main/tools/dep-checker)