### PR TITLE
chore(deps): bump typescript to ^6.0.3 in templates

### DIFF
--- a/generators/typescript_base/generator.go
+++ b/generators/typescript_base/generator.go
@@ -34,7 +34,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 				"build": "tsc",
 			},
 			"devDependencies": map[string]interface{}{
-				"typescript": "^5.4.0",
+				"typescript": "^6.0.3",
 			},
 		})
 		return nil

--- a/generators/typescript_base/manifest.go
+++ b/generators/typescript_base/manifest.go
@@ -8,7 +8,7 @@ const packageJSONFileName = "package.json"
 // the package.json + tsconfig.json that any TypeScript project needs.
 var Manifest = dotapi.Manifest{
 	Name:        "typescript_base",
-	Version:     "0.1.0",
+	Version:     "0.2.0",
 	Description: "TypeScript foundation: package.json + tsconfig.json",
 	DependsOn:   []string{"base_project"},
 	Outputs: []string{


### PR DESCRIPTION
## Dependency bump

Bumps `typescript` (npm) to `^6.0.3` in template generators.

### Affected generators

- `typescript_base `

---
🤖 Generated by [dep-checker](../tree/main/tools/dep-checker)