### PR TITLE
chore(deps): bump zod to ^4.4.3 in templates

### DIFF
--- a/generators/express_auth_validators/generator.go
+++ b/generators/express_auth_validators/generator.go
@@ -27,7 +27,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 	return ctx.State.UpdateJSON("package.json", func(d *state.JSONDoc) error {
 		d.Merge(map[string]interface{}{
 			"dependencies": map[string]interface{}{
-				"zod": "^3.23.8",
+				"zod": "^4.4.3",
 			},
 		})
 		return nil

--- a/generators/express_auth_validators/manifest.go
+++ b/generators/express_auth_validators/manifest.go
@@ -4,7 +4,7 @@ import "github.com/version14/dot/pkg/dotapi"
 
 var Manifest = dotapi.Manifest{
 	Name:        "express_auth_validators",
-	Version:     "0.1.0",
+	Version:     "0.2.0",
 	Description: "Zod schemas for auth endpoint input validation: register, login, refresh",
 	DependsOn:   []string{"express_server_entrypoint"},
 	Outputs:     []string{"src/shared/validators/auth.validators.ts"},

--- a/generators/zod_validation_deps/generator.go
+++ b/generators/zod_validation_deps/generator.go
@@ -16,7 +16,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 	if err := ctx.State.UpdateJSON("package.json", func(d *state.JSONDoc) error {
 		d.Merge(map[string]interface{}{
 			"dependencies": map[string]interface{}{
-				"zod":                            "^3.23.8",
+				"zod":                            "^4.4.3",
 				"@asteasolutions/zod-to-openapi": "^7.3.0",
 				"reflect-metadata":               "^0.2.2",
 				"swagger-ui-express":             "^5.0.1",

--- a/generators/zod_validation_deps/manifest.go
+++ b/generators/zod_validation_deps/manifest.go
@@ -6,7 +6,7 @@ var packageFileName = "package.json"
 
 var Manifest = dotapi.Manifest{
 	Name:        "zod_validation_deps",
-	Version:     "0.1.0",
+	Version:     "0.2.0",
 	Description: "Adds Zod, zod-to-openapi, swagger-ui-express, and reflect-metadata dependencies plus tsconfig flags for decorator metadata",
 	DependsOn:   []string{"typescript_base"},
 	Outputs:     []string{},


### PR DESCRIPTION
## Dependency bump

Bumps `zod` (npm) to `^4.4.3` in template generators.

### Affected generators

- `express_auth_validators `
- `zod_validation_deps `

---
🤖 Generated by [dep-checker](../tree/main/tools/dep-checker)