### PR TITLE
chore(deps): bump @types/cookie-parser,@types/cors @types/express,@types/jsonwebtoken @types/swagger-ui-express,better-auth cors,drizzle-kit drizzle-orm,jsonwebtoken nodemon,postgres prettier,supertest swagger-jsdoc,tsx in templates

### DIFF
--- a/generators/auth_better_auth/generator.go
+++ b/generators/auth_better_auth/generator.go
@@ -29,11 +29,11 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 	if err := ctx.State.UpdateJSON("package.json", func(d *state.JSONDoc) error {
 		d.Merge(map[string]interface{}{
 			"dependencies": map[string]interface{}{
-				"better-auth":   "^1.2.0",
+				"better-auth":   "^1.6.11",
 				"cookie-parser": "^1.4.7",
 			},
 			"devDependencies": map[string]interface{}{
-				"@types/cookie-parser": "^1.4.8",
+				"@types/cookie-parser": "^1.4.10",
 			},
 		})
 		return nil

--- a/generators/auth_better_auth/manifest.go
+++ b/generators/auth_better_auth/manifest.go
@@ -4,7 +4,7 @@ import "github.com/version14/dot/pkg/dotapi"
 
 var Manifest = dotapi.Manifest{
 	Name:        "auth_better_auth",
-	Version:     "0.2.0",
+	Version:     "0.2.2",
 	Description: "BetterAuth setup with Drizzle adapter: src/lib/auth.ts plus a direct toNodeHandler mount in src/app.ts (no intermediate route file)",
 	DependsOn:   []string{"drizzle_postgres_adapter"},
 	Outputs: []string{

--- a/generators/auth_jwt_vanilla/generator.go
+++ b/generators/auth_jwt_vanilla/generator.go
@@ -30,12 +30,12 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 	if err := ctx.State.UpdateJSON("package.json", func(d *state.JSONDoc) error {
 		d.Merge(map[string]interface{}{
 			"dependencies": map[string]interface{}{
-				"jsonwebtoken":  "^9.0.2",
+				"jsonwebtoken":  "^9.0.3",
 				"cookie-parser": "^1.4.7",
 			},
 			"devDependencies": map[string]interface{}{
-				"@types/jsonwebtoken":  "^9.0.7",
-				"@types/cookie-parser": "^1.4.8",
+				"@types/jsonwebtoken":  "^9.0.10",
+				"@types/cookie-parser": "^1.4.10",
 			},
 		})
 		return nil

--- a/generators/auth_jwt_vanilla/manifest.go
+++ b/generators/auth_jwt_vanilla/manifest.go
@@ -4,7 +4,7 @@ import "github.com/version14/dot/pkg/dotapi"
 
 var Manifest = dotapi.Manifest{
 	Name:        "auth_jwt_vanilla",
-	Version:     "0.1.0",
+	Version:     "0.1.3",
 	Description: "Vanilla JWT authentication: src/shared/services/jwt.ts utility and src/shared/middlewares/auth.middleware.ts",
 	DependsOn:   []string{"express_server_entrypoint"},
 	Outputs: []string{

--- a/generators/drizzle_postgres_adapter/generator.go
+++ b/generators/drizzle_postgres_adapter/generator.go
@@ -27,7 +27,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 	return ctx.State.UpdateJSON("package.json", func(d *state.JSONDoc) error {
 		d.Merge(map[string]interface{}{
 			"dependencies": map[string]interface{}{
-				"postgres": "^3.4.0",
+				"postgres": "^3.4.9",
 			},
 		})
 		return nil

--- a/generators/drizzle_postgres_adapter/manifest.go
+++ b/generators/drizzle_postgres_adapter/manifest.go
@@ -4,7 +4,7 @@ import "github.com/version14/dot/pkg/dotapi"
 
 var Manifest = dotapi.Manifest{
 	Name:        "drizzle_postgres_adapter",
-	Version:     "0.1.0",
+	Version:     "0.1.1",
 	Description: "PostgreSQL driver and database connection file for Drizzle ORM (src/db/index.ts)",
 	DependsOn:   []string{"drizzle_typescript_deps"},
 	Outputs: []string{

--- a/generators/drizzle_typescript_deps/generator.go
+++ b/generators/drizzle_typescript_deps/generator.go
@@ -22,10 +22,10 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 				"db:studio":   "drizzle-kit studio",
 			},
 			"dependencies": map[string]interface{}{
-				"drizzle-orm": "^0.44.0",
+				"drizzle-orm": "^0.45.2",
 			},
 			"devDependencies": map[string]interface{}{
-				"drizzle-kit": "^0.30.0",
+				"drizzle-kit": "^0.31.10",
 			},
 		})
 		return nil

--- a/generators/drizzle_typescript_deps/manifest.go
+++ b/generators/drizzle_typescript_deps/manifest.go
@@ -6,7 +6,7 @@ const PACKAGE_JSON = "package.json"
 
 var Manifest = dotapi.Manifest{
 	Name:        "drizzle_typescript_deps",
-	Version:     "0.1.0",
+	Version:     "0.1.2",
 	Description: "Adds drizzle-orm and drizzle-kit to package.json and db:* scripts",
 	DependsOn:   []string{"drizzle_config_base"},
 	Outputs:     []string{},

--- a/generators/express_server_typescript_deps/generator.go
+++ b/generators/express_server_typescript_deps/generator.go
@@ -21,16 +21,16 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 				"start": "node dist/index.js",
 			},
 			"dependencies": map[string]interface{}{
-				"cors":    "^2.8.5",
+				"cors":    "^2.8.6",
 				"dotenv":  "^16.4.0",
 				"express": "^4.21.0",
 			},
 			"devDependencies": map[string]interface{}{
-				"@types/cors":    "^2.8.17",
-				"@types/express": "^5.0.0",
+				"@types/cors":    "^2.8.19",
+				"@types/express": "^5.0.6",
 				"@types/node":    "^22.0.0",
-				"nodemon":        "^3.1.0",
-				"tsx":            "^4.19.0",
+				"nodemon":        "^3.1.14",
+				"tsx":            "^4.22.3",
 			},
 		})
 		return nil

--- a/generators/express_server_typescript_deps/manifest.go
+++ b/generators/express_server_typescript_deps/manifest.go
@@ -4,7 +4,7 @@ import "github.com/version14/dot/pkg/dotapi"
 
 var Manifest = dotapi.Manifest{
 	Name:        "express_server_typescript_deps",
-	Version:     "0.1.0",
+	Version:     "0.1.5",
 	Description: "Express + CORS + dotenv npm dependencies and dev/build/start scripts for TypeScript projects",
 	DependsOn:   []string{"express_server_entrypoint"},
 	Outputs:     []string{},

--- a/generators/express_swagger_jsdoc/generator.go
+++ b/generators/express_swagger_jsdoc/generator.go
@@ -31,12 +31,12 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 	if err := ctx.State.UpdateJSON("package.json", func(d *state.JSONDoc) error {
 		d.Merge(map[string]interface{}{
 			"dependencies": map[string]interface{}{
-				"swagger-jsdoc":      "^6.2.8",
+				"swagger-jsdoc":      "^6.3.0",
 				"swagger-ui-express": "^5.0.1",
 			},
 			"devDependencies": map[string]interface{}{
 				"@types/swagger-jsdoc":      "^6.0.4",
-				"@types/swagger-ui-express": "^4.1.6",
+				"@types/swagger-ui-express": "^4.1.8",
 			},
 		})
 		return nil

--- a/generators/express_swagger_jsdoc/manifest.go
+++ b/generators/express_swagger_jsdoc/manifest.go
@@ -4,7 +4,7 @@ import "github.com/version14/dot/pkg/dotapi"
 
 var Manifest = dotapi.Manifest{
 	Name:        "express_swagger_jsdoc",
-	Version:     "0.1.0",
+	Version:     "0.1.2",
 	Description: "Classic JSDoc-driven Swagger/OpenAPI: scans source files for @openapi comments, builds the spec at boot, and mounts swagger-ui at /docs",
 	DependsOn:   []string{"express_server_entrypoint"},
 	Outputs: []string{

--- a/generators/express_test_setup/generator.go
+++ b/generators/express_test_setup/generator.go
@@ -32,7 +32,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 			"devDependencies": map[string]interface{}{
 				"vitest":              "^2.0.0",
 				"@vitest/coverage-v8": "^2.0.0",
-				"supertest":           "^7.0.0",
+				"supertest":           "^7.2.2",
 				"@types/supertest":    "^6.0.0",
 			},
 		})

--- a/generators/express_test_setup/manifest.go
+++ b/generators/express_test_setup/manifest.go
@@ -4,7 +4,7 @@ import "github.com/version14/dot/pkg/dotapi"
 
 var Manifest = dotapi.Manifest{
 	Name:        "express_test_setup",
-	Version:     "0.1.0",
+	Version:     "0.1.1",
 	Description: "Vitest configuration and testing dependencies (vitest, supertest) for Express TypeScript projects",
 	DependsOn:   []string{"express_server_entrypoint"},
 	Outputs:     []string{"vitest.config.ts"},

--- a/generators/prettier_typescript_deps/generator.go
+++ b/generators/prettier_typescript_deps/generator.go
@@ -20,7 +20,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 				"format:check": "prettier --check .",
 			},
 			"devDependencies": map[string]interface{}{
-				"prettier": "^3.2.0",
+				"prettier": "^3.8.3",
 			},
 		})
 		return nil

--- a/generators/prettier_typescript_deps/manifest.go
+++ b/generators/prettier_typescript_deps/manifest.go
@@ -4,7 +4,7 @@ import "github.com/version14/dot/pkg/dotapi"
 
 var Manifest = dotapi.Manifest{
 	Name:        "prettier_typescript_deps",
-	Version:     "0.1.0",
+	Version:     "0.1.1",
 	Description: "Adds prettier devDependency and format script to package.json (TypeScript projects)",
 	DependsOn:   []string{"prettier_config", "*"},
 	Outputs:     []string{},

--- a/generators/zod_validation_deps/generator.go
+++ b/generators/zod_validation_deps/generator.go
@@ -22,7 +22,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 				"swagger-ui-express":             "^5.0.1",
 			},
 			"devDependencies": map[string]interface{}{
-				"@types/swagger-ui-express": "^4.1.6",
+				"@types/swagger-ui-express": "^4.1.8",
 			},
 		})
 		return nil

--- a/generators/zod_validation_deps/manifest.go
+++ b/generators/zod_validation_deps/manifest.go
@@ -6,7 +6,7 @@ var packageFileName = "package.json"
 
 var Manifest = dotapi.Manifest{
 	Name:        "zod_validation_deps",
-	Version:     "0.1.0",
+	Version:     "0.1.1",
 	Description: "Adds Zod, zod-to-openapi, swagger-ui-express, and reflect-metadata dependencies plus tsconfig flags for decorator metadata",
 	DependsOn:   []string{"typescript_base"},
 	Outputs:     []string{},


### PR DESCRIPTION
## Dependency bump

Bumps `@types/cookie-parser,@types/cors @types/express,@types/jsonwebtoken @types/swagger-ui-express,better-auth cors,drizzle-kit drizzle-orm,jsonwebtoken nodemon,postgres prettier,supertest swagger-jsdoc,tsx` (npm) in template generators.

### Affected generators

- `auth_better_auth `
- `auth_better_auth `
- `auth_jwt_vanilla `
- `auth_jwt_vanilla `
- `auth_jwt_vanilla `
- `drizzle_postgres_adapter `
- `drizzle_typescript_deps `
- `drizzle_typescript_deps `
- `express_server_typescript_deps `
- `express_server_typescript_deps `
- `express_server_typescript_deps `
- `express_server_typescript_deps `
- `express_server_typescript_deps `
- `express_swagger_jsdoc `
- `express_swagger_jsdoc `
- `express_test_setup `
- `prettier_typescript_deps `
- `zod_validation_deps `

---
🤖 Generated by [dep-checker](../tree/main/tools/dep-checker)