### PR TITLE
chore(deps): bump @types/node in templates

### DIFF
--- a/generators/ark_ui/generator.go
+++ b/generators/ark_ui/generator.go
@@ -22,7 +22,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 	if err := ctx.State.UpdateJSON("package.json", func(d *state.JSONDoc) error {
 		d.Merge(map[string]interface{}{
 			"dependencies": map[string]interface{}{
-				"@ark-ui/react": "^5.37.0",
+				"@ark-ui/react": "^5.37.2",
 			},
 		})
 		return nil

--- a/generators/auth_better_auth/generator.go
+++ b/generators/auth_better_auth/generator.go
@@ -29,7 +29,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 	if err := ctx.State.UpdateJSON("package.json", func(d *state.JSONDoc) error {
 		d.Merge(map[string]interface{}{
 			"dependencies": map[string]interface{}{
-				"better-auth":   "^1.6.11",
+				"better-auth":   "^1.6.20",
 				"cookie-parser": "^1.4.7",
 			},
 			"devDependencies": map[string]interface{}{

--- a/generators/auth_better_auth_frontend/generator.go
+++ b/generators/auth_better_auth_frontend/generator.go
@@ -28,7 +28,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 	if err := ctx.State.UpdateJSON("package.json", func(d *state.JSONDoc) error {
 		d.Merge(map[string]interface{}{
 			"dependencies": map[string]interface{}{
-				"better-auth": "^1.6.11",
+				"better-auth": "^1.6.20",
 			},
 		})
 		return nil

--- a/generators/biome_config/generator.go
+++ b/generators/biome_config/generator.go
@@ -75,7 +75,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 				"format": "biome format --write .",
 			},
 			"devDependencies": map[string]interface{}{
-				"@biomejs/biome": "^2.4.16",
+				"@biomejs/biome": "^2.5.1",
 			},
 		})
 		return nil

--- a/generators/express_server_typescript_deps/generator.go
+++ b/generators/express_server_typescript_deps/generator.go
@@ -28,9 +28,9 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 			"devDependencies": map[string]interface{}{
 				"@types/cors":    "^2.8.19",
 				"@types/express": "^5.0.6",
-				"@types/node":    "^25.9.1",
+				"@types/node":    "^26.0.0",
 				"nodemon":        "^3.1.14",
-				"tsx":            "^4.22.3",
+				"tsx":            "^4.22.4",
 			},
 		})
 		return nil

--- a/generators/express_test_setup/generator.go
+++ b/generators/express_test_setup/generator.go
@@ -30,8 +30,8 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 				"test:coverage": "vitest run --coverage",
 			},
 			"devDependencies": map[string]interface{}{
-				"vitest":              "^4.1.7",
-				"@vitest/coverage-v8": "^4.1.7",
+				"vitest":              "^4.1.9",
+				"@vitest/coverage-v8": "^4.1.9",
 				"supertest":           "^7.2.2",
 				"@types/supertest":    "^7.2.0",
 			},

--- a/generators/feature_flags_posthog/generator.go
+++ b/generators/feature_flags_posthog/generator.go
@@ -27,7 +27,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 	if err := ctx.State.UpdateJSON("package.json", func(d *state.JSONDoc) error {
 		d.Merge(map[string]interface{}{
 			"dependencies": map[string]interface{}{
-				"posthog-js": "^1.376.4",
+				"posthog-js": "^1.393.1",
 			},
 		})
 		return nil

--- a/generators/jotai_setup/generator.go
+++ b/generators/jotai_setup/generator.go
@@ -22,7 +22,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 	if err := ctx.State.UpdateJSON("package.json", func(d *state.JSONDoc) error {
 		d.Merge(map[string]interface{}{
 			"dependencies": map[string]interface{}{
-				"jotai": "^2.20.0",
+				"jotai": "^2.20.1",
 			},
 		})
 		return nil

--- a/generators/nextjs_base/generator.go
+++ b/generators/nextjs_base/generator.go
@@ -40,13 +40,13 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 				"lint":  "next lint",
 			},
 			"dependencies": map[string]interface{}{
-				"next":      "^16.2.6",
-				"react":     "^19.2.6",
-				"react-dom": "^19.2.6",
+				"next":      "^16.2.9",
+				"react":     "^19.2.7",
+				"react-dom": "^19.2.7",
 			},
 			"devDependencies": map[string]interface{}{
-				"@types/node":      "^25.9.1",
-				"@types/react":     "^19.2.15",
+				"@types/node":      "^26.0.0",
+				"@types/react":     "^19.2.17",
 				"@types/react-dom": "^19.2.3",
 			},
 		})

--- a/generators/playwright_setup/generator.go
+++ b/generators/playwright_setup/generator.go
@@ -39,7 +39,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 				"test:e2e": "playwright test",
 			},
 			"devDependencies": map[string]interface{}{
-				"@playwright/test": "^1.60.0",
+				"@playwright/test": "^1.61.1",
 			},
 		})
 		return nil

--- a/generators/prettier_typescript_deps/generator.go
+++ b/generators/prettier_typescript_deps/generator.go
@@ -20,7 +20,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 				"format:check": "prettier --check .",
 			},
 			"devDependencies": map[string]interface{}{
-				"prettier": "^3.8.3",
+				"prettier": "^3.8.4",
 			},
 		})
 		return nil

--- a/generators/react_app/generator.go
+++ b/generators/react_app/generator.go
@@ -39,14 +39,14 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 				"preview": "vite preview",
 			},
 			"dependencies": map[string]interface{}{
-				"react":     "^19.2.6",
-				"react-dom": "^19.2.6",
+				"react":     "^19.2.7",
+				"react-dom": "^19.2.7",
 			},
 			"devDependencies": map[string]interface{}{
-				"@types/react":         "^19.2.15",
+				"@types/react":         "^19.2.17",
 				"@types/react-dom":     "^19.2.3",
-				"@vitejs/plugin-react": "^6.0.2",
-				"vite":                 "^8.0.14",
+				"@vitejs/plugin-react": "^6.0.3",
+				"vite":                 "^8.1.0",
 			},
 		})
 		return nil

--- a/generators/react_router_v7/generator.go
+++ b/generators/react_router_v7/generator.go
@@ -23,7 +23,7 @@ func (g *Generator) Generate(ctx *dotapi.Context) error {
 		d.Merge(map[string]interface{}{
 			"dependencies": map[string]interface{}{
 				"react-router":     "^8.0.1",
-				"react-router-dom": "^7.16.0",
+				"react-router-dom": "^7.18.0",
 			},
 		})
 		return nil


### PR DESCRIPTION
## Dependency bump

Bumps `@types/node` (npm) in template generators.

### Affected generators

- `express_server_typescript_deps `
- `nextjs_base `

---
🤖 Generated by [dep-checker](../tree/main/tools/dep-checker)