### PR TITLE
fix(ci): do not fail PRs on unrelated dependency updates

### DIFF
--- a/.github/workflows/dep-checker.yml
+++ b/.github/workflows/dep-checker.yml
@@ -109,12 +109,11 @@ jobs:
             echo "Created dep comment on PR #$PR_NUMBER."
           fi
 
-      - name: Fail PR on major/minor updates
+      - name: Warn about outstanding major/minor updates
         if: github.event_name == 'pull_request'
         run: |
           if jq -e '.entries[] | select(.outdated and (.update_type == "major" or .update_type == "minor"))' pr-dep-report.json > /dev/null; then
-            echo "Major/minor dependency updates detected in PR-changed generators. Failing PR check." >&2
-            exit 1
+            echo "::warning::Outstanding major/minor dependency updates were found in PR-changed generators. Review the dependency report before merging."
           fi
 
       - name: Upload scan report


### PR DESCRIPTION
## Summary

Changes the template dependency check from a blocking failure to a GitHub Actions warning when it finds outstanding major/minor updates in generators touched by a PR.

The dependency report remains available for review, but a PR is no longer blocked by unrelated stale dependencies in the same generator.

## Validation

- YAML parse passed
- `git diff --check` passed

Fixes the false failure pattern seen in #157.