### PR TITLE
chore(deps)!: migrate `typescript` ^6.0.3 → ^7.0.2

### DIFF
--- a/internal/deps/npm.go
+++ b/internal/deps/npm.go
@@ -79,7 +79,7 @@ var npm = map[string]string{
 	"tailwind-merge":                 "^3.6.0",
 	"tailwindcss":                    "^4.3.0",
 	"tsx":                            "^4.22.4",
-	"typescript":                     "^6.0.3",
+	"typescript":                     "^7.0.2",
 	"vite":                           "^8.0.16",
 	"vitest":                         "^4.1.8",
 	"zod":                            "^4.4.3",


### PR DESCRIPTION
## Migration: `typescript`

`^6.0.3` → `^7.0.2`

**This breaks the existing constraint**, so it is not a routine bump — the package is signalling a breaking change. Generator code or templates may need to change alongside it.

CI will tell you: if test-flows passes as-is, this is just a version bump after all. If it fails, that failure *is* the work.

This branch is yours now — the bot will not touch it again. Leaving this PR open tells the bot you have this in hand, and keeps `typescript` out of the Rollup.

---
🤖 [dep-checker](../tree/main/tools/dep-checker)